### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -44,7 +44,10 @@ def serve():
 
 @app.route("/<path:path>")
 def static_proxy(path):
-    file_path = os.path.join(app.static_folder, path)
+    normalized_path = os.path.normpath(path)
+    if not os.path.commonprefix([app.static_folder, os.path.join(app.static_folder, normalized_path)]) == app.static_folder:
+        return jsonify({"error": "Invalid path"}), 404
+    file_path = os.path.join(app.static_folder, normalized_path)
     if os.path.exists(file_path):
         return send_from_directory(app.static_folder, path)
     else:


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/AlphaTest/security/code-scanning/1](https://github.com/ajharris/AlphaTest/security/code-scanning/1)

To fix the issue, we need to validate the `path` variable before constructing the `file_path`. The best approach is to normalize the path using `os.path.normpath` and ensure that the resulting path is contained within the `app.static_folder` directory. This prevents path traversal attacks by ensuring that the user cannot access files outside the intended directory.

Steps to implement the fix:
1. Normalize the `path` using `os.path.normpath`.
2. Check that the normalized path starts with `app.static_folder` using `os.path.commonprefix`.
3. If the validation fails, return a 404 error or another appropriate response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
