### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -102,11 +102,11 @@ def serve():
 @app.route("/<path:path>")
 def static_proxy(path):
     normalized_path = os.path.normpath(path)
-    if not os.path.commonprefix([app.static_folder, os.path.join(app.static_folder, normalized_path)]) == app.static_folder:
+    full_path = os.path.realpath(os.path.join(app.static_folder, normalized_path))
+    if not full_path.startswith(os.path.realpath(app.static_folder)):
         return jsonify({"error": "Invalid path"}), 404
-    file_path = os.path.join(app.static_folder, normalized_path)
-    if os.path.exists(file_path):
-        return send_from_directory(app.static_folder, path)
+    if os.path.exists(full_path):
+        return send_from_directory(app.static_folder, os.path.relpath(full_path, app.static_folder))
     else:
         return send_from_directory(app.static_folder, "index.html")
 


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/AlphaTest/security/code-scanning/1](https://github.com/ajharris/AlphaTest/security/code-scanning/1)

To fix the issue, we will implement a more robust validation mechanism for the `path` parameter. Specifically, we will:

1. Normalize the user-provided path using `os.path.normpath`.
2. Construct the full file path by joining the normalized path with `app.static_folder`.
3. Use `os.path.realpath` to resolve the full path and ensure it is strictly within `app.static_folder`. This approach accounts for symbolic links and other filesystem quirks.
4. If the resolved path is not within `app.static_folder`, return an error response.
5. Use the validated path for file access.

This fix ensures that the file access is restricted to the intended directory and prevents path traversal attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
